### PR TITLE
Fix middleware null check and user error message

### DIFF
--- a/server/middleware.js
+++ b/server/middleware.js
@@ -63,12 +63,12 @@ module.exports.findGame = async function (req, res, next) {
     .populate("trackGroups")
     .populate("voteGroups");
 
-  await removeDuplicateGroups(game);
-
   if (!game) {
     res.status(404).json({ message: `No game found with ID ${gameId}` });
     return;
   }
+
+  await removeDuplicateGroups(game);
   req.game = game;
   next();
 };

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -96,7 +96,7 @@ router.put(
       if (!game) {
         return res
           .status(404)
-          .json({ error: `Game with code ${code} not found` });
+          .json({ error: `Game with id ${id} not found` });
       }
 
       req.user.games.push(game._id);


### PR DESCRIPTION
## Summary
- avoid calling `removeDuplicateGroups` when no game is found
- correct error response in user route when adding a game to a user

## Testing
- `npm test` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffcce392483309b17ef4a87daad06